### PR TITLE
Always add view_id into records

### DIFF
--- a/lib/embulk/input/google_analytics/client.rb
+++ b/lib/embulk/input/google_analytics/client.rb
@@ -54,6 +54,7 @@ module Embulk
               raw_time = format_row[task["time_series"]]
               next if too_early_data?(raw_time)
               format_row[task["time_series"]] = time_parse_with_profile_timezone(raw_time)
+              format_row["view_id"] = view_id
               block.call format_row
             end
 

--- a/lib/embulk/input/google_analytics/plugin.rb
+++ b/lib/embulk/input/google_analytics/plugin.rb
@@ -36,6 +36,8 @@ module Embulk
             Column.new(nil, canonicalize_column_name(col_name), col_type)
           end
 
+          columns << Column.new(nil, "view_id", :string)
+
           resume(task, columns, 1, &control)
         end
 
@@ -81,7 +83,7 @@ module Embulk
 
         def run
           client = Client.new(task, preview?)
-          columns = self.class.columns_from_task(task)
+          columns = self.class.columns_from_task(task) + ["view_id"]
 
           last_record_time = task["last_record_time"] ? Time.parse(task["last_record_time"]) : nil
 

--- a/test/embulk/input/google_analytics/test_client.rb
+++ b/test/embulk/input/google_analytics/test_client.rb
@@ -271,7 +271,8 @@ module Embulk
         sub_test_case "each_report_row" do
           setup do
             conf = valid_config["in"]
-            @client = Client.new(task(embulk_config(conf)))
+            @task = task(embulk_config(conf))
+            @client = Client.new(@task)
             stub(@client).get_profile { {timezone: "Asia/Tokyo"} }
             @logger = Logger.new(File::NULL)
             stub(Embulk).logger { @logger }
@@ -290,18 +291,21 @@ module Embulk
                 "ga:browser" => "curl",
                 "ga:visits" => "1",
                 "ga:pageviews" => "1",
+                "view_id" => @task["view_id"],
               },
               {
                 "ga:dateHour" => @client.time_parse_with_profile_timezone("2016060121"),
                 "ga:browser" => "curl",
                 "ga:visits" => "2",
                 "ga:pageviews" => "2",
+                "view_id" => @task["view_id"],
               },
               {
                 "ga:dateHour" => @client.time_parse_with_profile_timezone("2016060122"),
                 "ga:browser" => "curl",
                 "ga:visits" => "3",
                 "ga:pageviews" => "3",
+                "view_id" => @task["view_id"],
               },
             ]
             assert_equal expected, fetched_rows

--- a/test/embulk/input/google_analytics/test_plugin.rb
+++ b/test/embulk/input/google_analytics/test_plugin.rb
@@ -40,6 +40,7 @@ module Embulk
               Embulk::Column.new(nil, "browser", :string),
               Embulk::Column.new(nil, "visits", :long),
               Embulk::Column.new(nil, "pageviews", :long),
+              Embulk::Column.new(nil, "view_id", :string),
             ]
             mock(Plugin).resume(anything, columns, 1)
             Plugin.transaction(embulk_config(valid_config["in"]))
@@ -115,6 +116,7 @@ module Embulk
                 Column.new(nil, "ctr", :double),
                 Column.new(nil, "visits", :long),
                 Column.new(nil, "items_per_purchase", :double),
+                Column.new(nil, "view_id", :string),
               ]
 
               mock(Plugin).resume(anything, expected_columns, anything)
@@ -152,7 +154,7 @@ module Embulk
                   end
                 end
 
-                mock(@page_builder).add([time, "wget", 3, 4])
+                mock(@page_builder).add([time, "wget", 3, 4, nil]) # nil for view_id
                 mock(@page_builder).finish
                 @plugin.run
               end
@@ -209,7 +211,7 @@ module Embulk
                   end
                 end
 
-                mock(@page_builder).add([time, "wget", 3, 4])
+                mock(@page_builder).add([time, "wget", 3, 4, nil]) # nil for view_id
                 mock(@page_builder).finish
                 @plugin.run
               end


### PR DESCRIPTION
It is useful when a user ingesting data with some of views into single source.
