### PR TITLE
Add no-op guessing to avoid guess error

### DIFF
--- a/lib/embulk/input/google_analytics/plugin.rb
+++ b/lib/embulk/input/google_analytics/plugin.rb
@@ -84,6 +84,11 @@ module Embulk
           name.gsub(/^ga:/, "").gsub(/[A-Z]+/, "_\\0").gsub(/^_/, "").downcase
         end
 
+        def self.guess(config)
+          Embulk.logger.warn "Don't needed to guess for this plugin"
+          return {}
+        end
+
         def init
         end
 


### PR DESCRIPTION
Sometimes user trying to `embulk guess` with this plugin.
It fails because this plugin doesn't needed to do it.

This PR mitigate that surprise.
