### PR TITLE
Fix to generate end_date on config_diff 

### DIFF
--- a/lib/embulk/input/google_analytics/plugin.rb
+++ b/lib/embulk/input/google_analytics/plugin.rb
@@ -90,6 +90,10 @@ module Embulk
         end
 
         def init
+          # PLT-6753
+          if task["start_date"] && !task["end_date"]
+            task["end_date"] = "today"
+          end
         end
 
         def run

--- a/lib/embulk/input/google_analytics/plugin.rb
+++ b/lib/embulk/input/google_analytics/plugin.rb
@@ -137,6 +137,8 @@ module Embulk
             # Modify end_date as "today" to be safe
             if task["end_date"].nil? || task["end_date"].match(/[0-9]{4}-[0-9]{2}-[0-9]{2}/)
               task_report[:end_date] = "today" # "today" means now. running at 03:30 AM, will got 3 o'clock data.
+            else
+              task_report[:end_date] = task["end_date"]
             end
 
             # "start_date" format is YYYY-MM-DD, but ga:dateHour will return records by hourly.

--- a/test/embulk/input/google_analytics/test_plugin.rb
+++ b/test/embulk/input/google_analytics/test_plugin.rb
@@ -319,6 +319,7 @@ module Embulk
                   plugin = Plugin.new(config, nil, nil, @page_builder)
                   expected = {
                     start_date: latest_time.strftime("%Y-%m-%d"),
+                    end_date: @config[:end_date],
                     last_record_time: latest_time.strftime("%Y-%m-%d %H:%M:%S %z"),
                   }
                   assert_equal expected, plugin.calculate_next_times(latest_time)
@@ -394,6 +395,7 @@ module Embulk
                   plugin = Plugin.new(config, nil, nil, @page_builder)
                   expected = {
                     start_date: latest_time.strftime("%Y-%m-%d"),
+                    end_date: @config[:end_date],
                     last_record_time: latest_time.strftime("%Y-%m-%d %H:%M:%S %z"),
                   }
                   assert_equal expected, plugin.calculate_next_times(latest_time)


### PR DESCRIPTION
When end_date:"today", config_diff doesn't have a `end_date` key because it didn't set as `task_report[:end_date]`.
