### PR TITLE
Logging unexpected time string

### DIFF
--- a/lib/embulk/input/google_analytics/client.rb
+++ b/lib/embulk/input/google_analytics/client.rb
@@ -101,6 +101,10 @@ module Embulk
               "%Y%m%d"
             end
           parts = Date._strptime(time_string, date_format)
+          unless parts
+            # strptime was failed. Google API returns unexpected date string.
+            Embulk.logger.warn("Failed to parse #{task["time_series"]} data. The value is '#{time_string}'(#{time_string.class}) and it doesn't match with '#{date_format}'.")
+          end
 
           swap_time_zone do
             Time.zone.local(*parts.values_at(:year, :mon, :mday, :hour)).to_time

--- a/test/embulk/input/google_analytics/test_client.rb
+++ b/test/embulk/input/google_analytics/test_client.rb
@@ -172,6 +172,20 @@ module Embulk
               assert_equal Time.parse("2016-01-01 22:00:00 -08:00"), time
             end
 
+            sub_test_case "Logging invalid values" do
+              setup do
+                @logger = Logger.new(File::NULL)
+                stub(Embulk).logger { @logger }
+              end
+
+              test "empty" do
+                mock(@logger).warn(%Q|Failed to parse ga:dateHour data. The value is ''(String) and it doesn't match with '%Y%m%d%H'.|)
+                assert_raise do
+                  @client.time_parse_with_profile_timezone("")
+                end
+              end
+            end
+
             def time_series
               "ga:dateHour"
             end
@@ -190,6 +204,20 @@ module Embulk
             test "not in dst" do
               time = @client.time_parse_with_profile_timezone("2016010122")
               assert_equal Time.parse("2016-01-01 00:00:00 PST"), time
+            end
+
+            sub_test_case "Logging invalid values" do
+              setup do
+                @logger = Logger.new(File::NULL)
+                stub(Embulk).logger { @logger }
+              end
+
+              test "empty" do
+                mock(@logger).warn(%Q|Failed to parse ga:date data. The value is ''(String) and it doesn't match with '%Y%m%d'.|)
+                assert_raise do
+                  @client.time_parse_with_profile_timezone("")
+                end
+              end
             end
 
             def time_series


### PR DESCRIPTION
Sometimes failed to parse ga:date and/or ga:dateHour value.
Logging it to see what value is actually passed here.