### PR TITLE
Release v0.1.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.13 - 2017-03-28
+* Fixed bug `last_record_time` in `preview` mode [#20](https://github.com/treasure-data/embulk-input-google_analytics/pull/20)
+
 ## 0.1.12 - 2017-01-31
 * Support 'fooXXbar' column names [#19](https://github.com/treasure-data/embulk-input-google_analytics/pull/19)
 

--- a/embulk-input-google_analytics.gemspec
+++ b/embulk-input-google_analytics.gemspec
@@ -1,7 +1,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "embulk-input-google_analytics"
-  spec.version       = "0.1.12"
+  spec.version       = "0.1.13"
   spec.authors       = ["uu59"]
   spec.summary       = "Google Analytics input plugin for Embulk"
   spec.description   = "Loads records from Google Analytics."


### PR DESCRIPTION
# CHANGELOG

* Fixed bug `last_record_time` in `preview` mode [#20](https://github.com/treasure-data/embulk-input-google_analytics/pull/20)