### PR TITLE
Fixed version of google-api-client to avoid rake failure

### DIFF
--- a/embulk-input-google_analytics.gemspec
+++ b/embulk-input-google_analytics.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "httpclient"
-  spec.add_dependency "google-api-client", "0.10.2"
+  spec.add_dependency "google-api-client", "0.10.1"
   spec.add_dependency "signet"
   spec.add_dependency "activesupport" # for Time.zone.parse, Time.zone.now
   spec.add_dependency "perfect_retry", "~> 0.5"

--- a/embulk-input-google_analytics.gemspec
+++ b/embulk-input-google_analytics.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "httpclient"
-  spec.add_dependency "google-api-client", "~> 0.9"
+  spec.add_dependency "google-api-client", "0.10.2"
   spec.add_dependency "signet"
   spec.add_dependency "activesupport" # for Time.zone.parse, Time.zone.now
   spec.add_dependency "perfect_retry", "~> 0.5"


### PR DESCRIPTION
I got `rake` failure when building embulk-input-google_analytics v0.1.13 at my local env. Circle CI [as well](https://circleci.com/gh/treasure-data/embulk-input-google_analytics/90).
This failure is caused because google-api-client deprecated following option.
```ruby
Google::Apis::ClientOptions.default.use_net_http = true
```
https://github.com/treasure-data/embulk-input-google_analytics/blob/v0.1.13/lib/embulk/input/google_analytics/client.rb#L8


Stacktrace

```shell
NoMethodError: undefined method `use_net_http=' for #<Google::Apis::ClientOptions:0x49ced9c7>
      <main> at /home/ubuntu/embulk-input-google_analytics/lib/embulk/input/google_analytics/client.rb:8
     require at org/jruby/RubyKernel.java:956
      <main> at /home/ubuntu/embulk-input-google_analytics/lib/embulk/input/google_analytics.rb:1
     require at org/jruby/RubyKernel.java:956
...
```


I changed embulk-input-google_analytics.gemspec to use fixed version of google-api-client.