### PR TITLE
Fix mismatch timezone issue

### DIFF
--- a/lib/embulk/input/google_analytics/client.rb
+++ b/lib/embulk/input/google_analytics/client.rb
@@ -116,7 +116,8 @@ module Embulk
           end
 
           swap_time_zone do
-            Time.zone.local(*parts.values_at(:year, :mon, :mday, :hour)).to_time
+            local_time = Time.zone.local(*parts.values_at(:year, :mon, :mday, :hour))
+            local_time.getlocal(local_time.utc_offset)
           end
         end
 


### PR DESCRIPTION
to_time return the running worker localtime instead of the swapped
timezone time. Changed to use getlocaltime