### PR TITLE
Fix confused error message for invalid time format

### DIFF
--- a/lib/embulk/input/google_analytics/client.rb
+++ b/lib/embulk/input/google_analytics/client.rb
@@ -108,6 +108,7 @@ module Embulk
           unless parts
             # strptime was failed. Google API returns unexpected date string.
             Embulk.logger.warn("Failed to parse #{task["time_series"]} data. The value is '#{time_string}'(#{time_string.class}) and it doesn't match with '#{date_format}'.")
+            raise Embulk::DataError.new("Can't parse raw time returned from Google API, raw time is #{time_string}, expected format #{date_format}")
           end
 
           swap_time_zone do

--- a/lib/embulk/input/google_analytics/client.rb
+++ b/lib/embulk/input/google_analytics/client.rb
@@ -107,8 +107,7 @@ module Embulk
           parts = Date._strptime(time_string, date_format)
           unless parts
             # strptime was failed. Google API returns unexpected date string.
-            Embulk.logger.warn("Failed to parse #{task["time_series"]} data. The value is '#{time_string}'(#{time_string.class}) and it doesn't match with '#{date_format}'.")
-            raise Embulk::DataError.new("Can't parse raw time returned from Google API, raw time is #{time_string}, expected format #{date_format}")
+            raise Embulk::DataError.new("Failed to parse #{task["time_series"]} data. The value is '#{time_string}'(#{time_string.class}) and it doesn't match with '#{date_format}'.")
           end
 
           swap_time_zone do

--- a/test/embulk/input/google_analytics/test_client.rb
+++ b/test/embulk/input/google_analytics/test_client.rb
@@ -180,8 +180,7 @@ module Embulk
               end
 
               test "empty" do
-                mock(@logger).warn(%Q|Failed to parse ga:dateHour data. The value is ''(String) and it doesn't match with '%Y%m%d%H'.|)
-                assert_raise Embulk::DataError.new("Can't parse raw time returned from Google API, raw time is , expected format %Y%m%d%H") do
+                assert_raise Embulk::DataError.new(%Q|Failed to parse ga:dateHour data. The value is ''(String) and it doesn't match with '%Y%m%d%H'.|) do
                   @client.time_parse_with_profile_timezone("")
                 end
               end
@@ -214,8 +213,7 @@ module Embulk
               end
 
               test "empty" do
-                mock(@logger).warn(%Q|Failed to parse ga:date data. The value is ''(String) and it doesn't match with '%Y%m%d'.|)
-                assert_raise do
+                assert_raise Embulk::DataError.new(%Q|Failed to parse ga:date data. The value is ''(String) and it doesn't match with '%Y%m%d'.|) do
                   @client.time_parse_with_profile_timezone("")
                 end
               end

--- a/test/embulk/input/google_analytics/test_client.rb
+++ b/test/embulk/input/google_analytics/test_client.rb
@@ -181,7 +181,7 @@ module Embulk
 
               test "empty" do
                 mock(@logger).warn(%Q|Failed to parse ga:dateHour data. The value is ''(String) and it doesn't match with '%Y%m%d%H'.|)
-                assert_raise do
+                assert_raise Embulk::DataError.new("Can't parse raw time returned from Google API, raw time is , expected format %Y%m%d%H") do
                   @client.time_parse_with_profile_timezone("")
                 end
               end


### PR DESCRIPTION
Throw DataError when encounter invalid time format from Google API
instead of undefined method error