### PR TITLE
Oauth support

### DIFF
--- a/test/embulk/input/google_analytics/test_plugin.rb
+++ b/test/embulk/input/google_analytics/test_plugin.rb
@@ -75,6 +75,46 @@ module Embulk
               end
             end
 
+            test "missing client_id params for oauth" do
+              conf = valid_config_oauth["in"]
+              conf.delete("client_id")
+              assert_raise(Embulk::ConfigError.new(oauth_expect_message)) do
+                Plugin.transaction(embulk_config(conf))
+              end
+            end
+
+            test "missing client_secret params for oauth" do
+              conf = valid_config_oauth["in"]
+              conf.delete('client_secret')
+              assert_raise(Embulk::ConfigError.new(oauth_expect_message)) do
+                Plugin.transaction(embulk_config(conf))
+              end
+            end
+
+            test "missing refresh_token params for oauth" do
+              conf = valid_config_oauth["in"]
+              conf.delete("refresh_token")
+              assert_raise(Embulk::ConfigError.new(unknown_auth_method_message)) do
+                Plugin.transaction(embulk_config(conf))
+              end
+            end
+
+            test "missing json_key_content params for oauth" do
+              conf = valid_config["in"]
+              conf.delete("json_key_content")
+              assert_raise(Embulk::ConfigError.new(unknown_auth_method_message)) do
+                Plugin.transaction(embulk_config(conf))
+              end
+            end
+
+            def unknown_auth_method_message
+              "Unknown Authentication method ''."
+            end
+
+            def oauth_expect_message
+              "client_id, client_secret and refresh_token are required when using Oauth authentication"
+            end
+
             def unknown_col_name
               "ga:foooooo"
             end
@@ -456,6 +496,10 @@ module Embulk
 
         def embulk_config(hash)
           Embulk::DataSource.new(hash)
+        end
+
+        def valid_config_oauth
+          fixture_load("valid_refresh_token.yml")
         end
       end
     end

--- a/test/fixtures/valid_refresh_token.yml
+++ b/test/fixtures/valid_refresh_token.yml
@@ -1,0 +1,18 @@
+in:
+  type: google_analytics
+  refresh_token: "your_refresh_token"
+  client_id: "your_client_id_here"
+  client_secret: "your_client_secret_here"
+  view_id: 101111111
+  time_series: "ga:dateHour"
+ 
+  dimensions:
+    - "ga:browser"
+  metrics:
+    - "ga:visits"
+    - "ga:pageviews"
+  retry_limit: 2
+  retry_initial_wait_sec: 0
+
+out:
+  type: stdout


### PR DESCRIPTION
Add Oauth support for this plugin. allow client_id, client_secret and refresh_token input
