### PR TITLE
Hotfix - throw uncheck exception when last_record_time is null

### DIFF
--- a/lib/embulk/input/google_analytics/plugin.rb
+++ b/lib/embulk/input/google_analytics/plugin.rb
@@ -196,13 +196,19 @@ module Embulk
             task_report[:last_record_time] = fetched_latest_time.strftime("%Y-%m-%d %H:%M:%S %z")
           else
             # no records fetched, don't modify config_diff
-            task_report = {
-              start_date: task["start_date"],
-              end_date: task["end_date"],
-              last_record_time: task["last_record_time"],
-            }
+            if task["last_record_time"] && !task["last_record_time"].empty?
+              task_report = {
+                start_date: task["start_date"],
+                end_date: task["end_date"],
+                last_record_time: task["last_record_time"]
+              }
+            else
+              task_report = {
+                start_date: task["start_date"],
+                end_date: task["end_date"]
+              }
+            end
           end
-
           task_report
         end
       end

--- a/test/embulk/input/google_analytics/test_plugin.rb
+++ b/test/embulk/input/google_analytics/test_plugin.rb
@@ -365,7 +365,7 @@ module Embulk
                 expected = {
                   start_date: task["start_date"],
                   end_date: task["end_date"],
-                  last_record_time: task["last_record_time"],
+                  # last_record_time: task["last_record_time"],
                 }
                 assert_equal expected, plugin.calculate_next_times(DEFAULT_TIMEZONE, nil)
               end
@@ -441,7 +441,7 @@ module Embulk
                 expected = {
                   start_date: task["start_date"],
                   end_date: task["end_date"],
-                  last_record_time: task["last_record_time"],
+                  # last_record_time: task["last_record_time"],
                 }
                 assert_equal expected, plugin.calculate_next_times(DEFAULT_TIMEZONE, nil)
               end


### PR DESCRIPTION
#### Change log
* do not output last_record_time when null