### PR TITLE
Make it easy to understand error message of Google Analytics connector

### DIFF
--- a/lib/embulk/input/google_analytics/plugin.rb
+++ b/lib/embulk/input/google_analytics/plugin.rb
@@ -111,8 +111,7 @@ module Embulk
         end
 
         def self.valid_json?(json_object)
-          # PLT-7625
-          # In some json library, 'null' string is a valid string for parse function
+          # 'null' string is a valid string for parse function
           # However in our case, json_content_key could not be 'null' therefore this check is added
           if json_object == "null"
               return false
@@ -126,7 +125,6 @@ module Embulk
         end
 
         def init
-          # PLT-6753
           if task["start_date"] && !task["end_date"]
             task["end_date"] = "today"
           end

--- a/lib/embulk/input/google_analytics/plugin.rb
+++ b/lib/embulk/input/google_analytics/plugin.rb
@@ -114,10 +114,12 @@ module Embulk
           if json_object == "null"
               return false
           end
-          JSON.parse(json_object)
-              return true
+          begin
+            JSON.parse(json_object)
+                return true
           rescue JSON::ParserError => e
               return false
+          end
         end
 
         def init

--- a/lib/embulk/input/google_analytics/plugin.rb
+++ b/lib/embulk/input/google_analytics/plugin.rb
@@ -111,6 +111,9 @@ module Embulk
         end
 
         def self.valid_json?(json_object)
+          # PLT-7625
+          # In some json library, 'null' string is a valid string for parse function
+          # However in our case, json_content_key could not be 'null' therefore this check is added
           if json_object == "null"
               return false
           end

--- a/lib/embulk/input/google_analytics/plugin.rb
+++ b/lib/embulk/input/google_analytics/plugin.rb
@@ -111,16 +111,13 @@ module Embulk
         end
 
         def self.valid_json?(json_object)
-          if !json_object.is_a? String
-              return false
-          elsif json_object == "null"
+          if json_object == "null"
               return false
           end
-              JSON.parse(json_object)
+          JSON.parse(json_object)
               return true
           rescue JSON::ParserError => e
               return false
-          return false
         end
 
         def init

--- a/lib/embulk/input/google_analytics/plugin.rb
+++ b/lib/embulk/input/google_analytics/plugin.rb
@@ -20,6 +20,10 @@ module Embulk
             unless task['client_id'] && task['client_secret'] && task['refresh_token']
               raise ConfigError.new("client_id, client_secret and refresh_token are required when using Oauth authentication")
             end
+          elsif task['auth_method'] == Plugin::AUTH_TYPE_JSON_KEY
+            if !valid_json?(task["json_key_content"])
+              raise ConfigError.new("json_key_content is not a valid JSON object")
+            end
           end
 
           columns_list = Client.new(task).get_columns_list
@@ -104,6 +108,19 @@ module Embulk
         def self.guess(config)
           Embulk.logger.warn "Don't needed to guess for this plugin"
           return {}
+        end
+
+        def self.valid_json?(json_object)
+          if !json_object.is_a? String
+              return false
+          elsif json_object == "null"
+              return false
+          end
+              JSON.parse(json_object)
+              return true
+          rescue JSON::ParserError => e
+              return false
+          return false
         end
 
         def init

--- a/test/embulk/input/google_analytics/test_plugin.rb
+++ b/test/embulk/input/google_analytics/test_plugin.rb
@@ -107,6 +107,26 @@ module Embulk
               end
             end
 
+            test "invalid json_key_content params for oauth" do
+              conf = valid_config["in"]
+              # Empty json_key_content
+              conf["json_key_content"] = ""
+              message = "json_key_content is not a valid JSON object"
+              assert_raise(Embulk::ConfigError.new(message)) do
+                Plugin.transaction(embulk_config(conf))
+              end
+              # null json_key_content
+              conf["json_key_content"] = "null"
+              assert_raise(Embulk::ConfigError.new(message)) do
+                Plugin.transaction(embulk_config(conf))
+              end
+              # Not a string json_key_content
+              conf["json_key_content"] = nil
+              assert_raise(Embulk::ConfigError.new(message)) do
+                Plugin.transaction(embulk_config(conf))
+              end
+            end
+
             def unknown_auth_method_message
               "Unknown Authentication method ''."
             end


### PR DESCRIPTION
Currently when user enter invalid JSON format for json_key_content, the message look so strange therefore it make user hard to understand. 
With this pull request, when user enter invalid JSON, the message will be "json_key_content is not a valid JSON object"