### PR TITLE
Fix (ArgumentError) no time information in "" when last_record_time is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.1.20 - 2019-04-01
+## 0.1.21 - 2019-04-01
 * Fix **(ArgumentError) no time information in ""** when last_record_time is null [#42](https://github.com/treasure-data/embulk-input-google_analytics/pull/42)
 
 ## 0.1.19 - 2018-10-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.20 - 2019-04-02
+* Fix **(ArgumentError) no time information in ""** when last_record_time is null
+
 ## 0.1.19 - 2018-10-03
 * Make it easy to understand error message of Google Analytics connector
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 0.1.20 - 2019-04-02
-* Fix **(ArgumentError) no time information in ""** when last_record_time is null
+* Fix **(ArgumentError) no time information in ""** when last_record_time is null [#42](https://github.com/treasure-data/embulk-input-google_analytics/pull/42)
 
 ## 0.1.19 - 2018-10-03
 * Make it easy to understand error message of Google Analytics connector

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.1.20 - 2019-04-02
+## 0.1.20 - 2019-04-01
 * Fix **(ArgumentError) no time information in ""** when last_record_time is null [#42](https://github.com/treasure-data/embulk-input-google_analytics/pull/42)
 
 ## 0.1.19 - 2018-10-03

--- a/embulk-input-google_analytics.gemspec
+++ b/embulk-input-google_analytics.gemspec
@@ -1,7 +1,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "embulk-input-google_analytics"
-	spec.version       = "0.1.20"
+	spec.version       = "0.1.21"
   spec.authors       = ["uu59"]
   spec.summary       = "Google Analytics input plugin for Embulk"
   spec.description   = "Loads records from Google Analytics."

--- a/embulk-input-google_analytics.gemspec
+++ b/embulk-input-google_analytics.gemspec
@@ -1,7 +1,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "embulk-input-google_analytics"
-	spec.version       = "0.1.19"
+	spec.version       = "0.1.20"
   spec.authors       = ["uu59"]
   spec.summary       = "Google Analytics input plugin for Embulk"
   spec.description   = "Loads records from Google Analytics."

--- a/lib/embulk/input/google_analytics/plugin.rb
+++ b/lib/embulk/input/google_analytics/plugin.rb
@@ -134,7 +134,7 @@ module Embulk
           client = Client.new(task, preview?)
           columns = self.class.columns_from_task(task) + ["view_id"]
 
-          last_record_time = Time.parse(task["last_record_time"]) if task['incremental'] && !task["last_record_time"].nil? && !task["last_record_time"].empty?
+          last_record_time = Time.parse(task["last_record_time"]) if task['incremental'] && !task["last_record_time"].blank?
           latest_time_series = nil
           skip_counter, total_counter = 0, 0
           client.each_report_row do |row|
@@ -217,7 +217,7 @@ module Embulk
               end_date: task["end_date"]
             }
             # write last_record_time only when last_record_time is not nil and not empty
-            unless task["last_record_time"].nil? || task["last_record_time"].empty?
+            unless task["last_record_time"].blank?
               task_report[:last_record_time] = task["last_record_time"]
             end 
           end

--- a/lib/embulk/input/google_analytics/plugin.rb
+++ b/lib/embulk/input/google_analytics/plugin.rb
@@ -134,8 +134,7 @@ module Embulk
           client = Client.new(task, preview?)
           columns = self.class.columns_from_task(task) + ["view_id"]
 
-          last_record_time = task['incremental'] && task["last_record_time"] ? Time.parse(task["last_record_time"]) : nil
-
+          last_record_time = Time.parse(task["last_record_time"]) if task['incremental'] && !task["last_record_time"].nil? && !task["last_record_time"].empty?
           latest_time_series = nil
           skip_counter, total_counter = 0, 0
           client.each_report_row do |row|
@@ -215,11 +214,13 @@ module Embulk
             # no records fetched, don't modify config_diff
             task_report = {
               start_date: task["start_date"],
-              end_date: task["end_date"],
-              last_record_time: task["last_record_time"],
+              end_date: task["end_date"]
             }
+            # write last_record_time only when last_record_time is not nil and not empty
+            unless task["last_record_time"].nil? || task["last_record_time"].empty?
+              task_report[:last_record_time] = task["last_record_time"]
+            end 
           end
-
           task_report
         end
       end

--- a/test/embulk/input/google_analytics/test_plugin.rb
+++ b/test/embulk/input/google_analytics/test_plugin.rb
@@ -379,13 +379,37 @@ module Embulk
               @config = embulk_config(conf)
             end
 
-            sub_test_case "no records fetched" do
+            sub_test_case "no records fetched and last_record_time is nil" do
               test "config_diff won't modify" do
                 plugin = Plugin.new(config, nil, nil, @page_builder)
                 expected = {
                   start_date: task["start_date"],
+                  end_date: task["end_date"]
+                }
+                assert_equal expected, plugin.calculate_next_times(DEFAULT_TIMEZONE, nil)
+              end
+            end
+
+            sub_test_case "no records fetched and last_record_time is empty" do
+              test "config_diff won't modify" do
+                config["last_record_time"] = ""
+                plugin = Plugin.new(config, nil, nil, @page_builder)
+                expected = {
+                  start_date: task["start_date"],
+                  end_date: task["end_date"]
+                }
+                assert_equal expected, plugin.calculate_next_times(DEFAULT_TIMEZONE, nil)
+              end
+            end
+
+            sub_test_case "no records fetched and last_record_time exist" do
+              test "config_diff won't modify" do
+                config["last_record_time"] = "2019-01-01"
+                plugin = Plugin.new(config, nil, nil, @page_builder)
+                expected = {
+                  start_date: task["start_date"],
                   end_date: task["end_date"],
-                  last_record_time: task["last_record_time"],
+                  last_record_time: task["last_record_time"]
                 }
                 assert_equal expected, plugin.calculate_next_times(DEFAULT_TIMEZONE, nil)
               end
@@ -452,6 +476,7 @@ module Embulk
             setup do
               conf = valid_config["in"]
               conf["time_series"] = "ga:date"
+              conf["last_record_time"] = "2019-01-01"
               @config = embulk_config(conf)
             end
 

--- a/test/embulk/input/google_analytics/test_plugin.rb
+++ b/test/embulk/input/google_analytics/test_plugin.rb
@@ -379,38 +379,23 @@ module Embulk
               @config = embulk_config(conf)
             end
 
-            sub_test_case "no records fetched and last_record_time is nil" do
-              test "config_diff won't modify" do
-                plugin = Plugin.new(config, nil, nil, @page_builder)
+            sub_test_case "no records fetched" do
+              data do
+              [
+                ["last_record_time is nil", [nil, nil]],
+                ["last_record_time is empty", ["", nil]],
+                ["last_record_time is blank", ["   ", nil]],
+                ["last_record_time is valid", ["2019-01-01", "2019-01-01"]]
+              ]
+              end
+              test "test calculate_next_times" do |(in_last_record_time, expected_last_record_time)|
+                config["last_record_time"] = in_last_record_time
                 expected = {
                   start_date: task["start_date"],
                   end_date: task["end_date"]
                 }
-                assert_equal expected, plugin.calculate_next_times(DEFAULT_TIMEZONE, nil)
-              end
-            end
-
-            sub_test_case "no records fetched and last_record_time is empty" do
-              test "config_diff won't modify" do
-                config["last_record_time"] = ""
+                expected[:last_record_time] = expected_last_record_time unless expected_last_record_time.blank?
                 plugin = Plugin.new(config, nil, nil, @page_builder)
-                expected = {
-                  start_date: task["start_date"],
-                  end_date: task["end_date"]
-                }
-                assert_equal expected, plugin.calculate_next_times(DEFAULT_TIMEZONE, nil)
-              end
-            end
-
-            sub_test_case "no records fetched and last_record_time exist" do
-              test "config_diff won't modify" do
-                config["last_record_time"] = "2019-01-01"
-                plugin = Plugin.new(config, nil, nil, @page_builder)
-                expected = {
-                  start_date: task["start_date"],
-                  end_date: task["end_date"],
-                  last_record_time: task["last_record_time"]
-                }
                 assert_equal expected, plugin.calculate_next_times(DEFAULT_TIMEZONE, nil)
               end
             end


### PR DESCRIPTION
Current situation:
* When schedule an incremental loading job with empty result set, the plugin create **last_record_time = null** in config diff after run successfully
* This lead to all followed jobs pick up this invalid value and cause the **(ArgumentError) no time information in ""** when trying to parse the last_record_time as time

Solution:
* Only write last_record_time in config diff whenever there are non-null value in previous run
* Add check to parse last_record_time whenever it is a non-null and non-empty value before run to support existed job run well

