### PR TITLE
Make plugin compatible with Ruby 2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.22 - 2019-10-24
+* Fix **Plugin's dependencies require Ruby > 2.3** [#44](https://github.com/treasure-data/embulk-input-google_analytics/pull/44)
+
 ## 0.1.21 - 2019-04-01
 * Fix **(ArgumentError) no time information in ""** when last_record_time is null [#42](https://github.com/treasure-data/embulk-input-google_analytics/pull/42)
 

--- a/embulk-input-google_analytics.gemspec
+++ b/embulk-input-google_analytics.gemspec
@@ -15,8 +15,13 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "httpclient"
   spec.add_dependency "google-api-client", "0.10.1"
+  # signet version > 11.0 requires Ruby version >= 2.4
+  # activesupport version > 5.2.3 requires Ruby version >= 2.5
+  # Current embulk version 0.9.19 runs under jRuby 9.1.x (which is compatible with Ruby 2.3)
+  # So decide to lock these gem versions to prevent incompatible Ruby version
   spec.add_dependency "signet", "0.11.0"
   spec.add_dependency "activesupport", "5.2.3" # for Time.zone.parse, Time.zone.now
+
   spec.add_dependency "perfect_retry", "~> 0.5"
 
   spec.add_development_dependency 'embulk', ['>= 0.8.9']

--- a/embulk-input-google_analytics.gemspec
+++ b/embulk-input-google_analytics.gemspec
@@ -1,7 +1,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "embulk-input-google_analytics"
-	spec.version       = "0.1.21"
+	spec.version       = "0.1.22"
   spec.authors       = ["uu59"]
   spec.summary       = "Google Analytics input plugin for Embulk"
   spec.description   = "Loads records from Google Analytics."
@@ -15,8 +15,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "httpclient"
   spec.add_dependency "google-api-client", "0.10.1"
-  spec.add_dependency "signet"
-  spec.add_dependency "activesupport" # for Time.zone.parse, Time.zone.now
+  spec.add_dependency "signet", "0.11.0"
+  spec.add_dependency "activesupport", "5.2.3" # for Time.zone.parse, Time.zone.now
   spec.add_dependency "perfect_retry", "~> 0.5"
 
   spec.add_development_dependency 'embulk', ['>= 0.8.9']


### PR DESCRIPTION
Current embulk version `0.9.19` run on [jRuby 9.1.15.0](https://github.com/embulk/embulk/blob/master/build.gradle#L49) which is fully compatible with [Ruby 2.3](https://github.com/jruby/jruby/wiki/Roadmap)

However some dependent gems inside this plugin have latest versions does require a ruby version higher than `2.3`:
* [signet](https://rubygems.org/gems/signet/)
* [activesupport](https://rubygems.org/gems/activesupport)

Which could cause a similar issue as https://github.com/embulk/embulk-output-bigquery/issues/113

The solution is to lock the dependencies with a version that compatible with `Ruby 2.3` (`jRuby 9.1.x`)
* [signet 0.11.0](https://rubygems.org/gems/signet/versions/0.11.0)
* [activesupport 5.2.3](https://rubygems.org/gems/activesupport/versions/5.2.3)