### PR TITLE
Lock signet and activesupport by less than or equal locked version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.23 - 2019-10-24
+Lock signet and activesupport by less than or equal locked version [#45](https://github.com/treasure-data/embulk-input-google_analytics/pull/45)
+
 ## 0.1.22 - 2019-10-24
 * Fix **Plugin's dependencies require Ruby > 2.3** [#44](https://github.com/treasure-data/embulk-input-google_analytics/pull/44)
 

--- a/embulk-input-google_analytics.gemspec
+++ b/embulk-input-google_analytics.gemspec
@@ -1,7 +1,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "embulk-input-google_analytics"
-	spec.version       = "0.1.22"
+	spec.version       = "0.1.23"
   spec.authors       = ["uu59"]
   spec.summary       = "Google Analytics input plugin for Embulk"
   spec.description   = "Loads records from Google Analytics."
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   # activesupport version > 5.2.3 requires Ruby version >= 2.5
   # Current embulk version 0.9.19 runs under jRuby 9.1.x (which is compatible with Ruby 2.3)
   # So decide to lock these gem versions to prevent incompatible Ruby version
-  spec.add_dependency "signet", "0.11.0"
-  spec.add_dependency "activesupport", "5.2.3" # for Time.zone.parse, Time.zone.now
+  spec.add_dependency "signet", "<= 0.11.0"
+  spec.add_dependency "activesupport", "<= 5.2.3" # for Time.zone.parse, Time.zone.now
 
   spec.add_dependency "perfect_retry", "~> 0.5"
 


### PR DESCRIPTION
Since in #44 we locked
- `signet` with exact version `0.11.0`
- `activesupport` with exact version `5.2.3`
However it is better to lock by `less than or equal version` `<= 0.11.0` and `<= 5.2.3`.
So this PR is for changing the `equal` to `less than equal` in gem's versions