### PR TITLE
Lock representable version

### DIFF
--- a/embulk-input-google_analytics.gemspec
+++ b/embulk-input-google_analytics.gemspec
@@ -17,10 +17,12 @@ Gem::Specification.new do |spec|
   spec.add_dependency "google-api-client", [">= 0.11", "< 0.33.0"]
   # signet version > 11.0 requires Ruby version >= 2.4
   # activesupport version > 5.2.3 requires Ruby version >= 2.5
+  # representable veresion > 3.1.0 requires Ruby version >= 2.4
   # Current embulk version 0.9.19 runs under jRuby 9.1.x (which is compatible with Ruby 2.3)
   # So decide to lock these gem versions to prevent incompatible Ruby version
   spec.add_dependency "signet", ['~> 0.7', "< 0.11.0"]
   spec.add_dependency "activesupport", "<= 5.2.3" # for Time.zone.parse, Time.zone.now
+  spec.add_dependency "representable", ['~> 3.0.0', '< 3.1']
 
   spec.add_dependency "perfect_retry", "~> 0.5"
 


### PR DESCRIPTION
Hello developers.

This PR fixes the same #46 problem.

[`representable`](https://rubygems.org/gems/representable/versions/3.1.0) gem released at 2021-04-10
It requires Ruby >= 2.4.0.

Embulk 0.9 still use jruby-9.1.5.0 and It's compatible Ruby 2.3
So when someone installs `embulk-input-google_analytics` on a new machine,
It will output the following error.

This PR lock `representable` gem version explicitly.

## Error

```
embulk gem install embulk-input-google_analytics
2021-04-15 18:14:03.657 +0900: Embulk v0.9.23

Gem plugin path is: /Users/user/.embulk/lib/gems

Fetching: httpclient-2.8.3.gem (100%)
Successfully installed httpclient-2.8.3
Fetching: uber-0.1.0.gem (100%)
Successfully installed uber-0.1.0
Fetching: declarative-0.0.20.gem (100%)
Successfully installed declarative-0.0.20
Fetching: trailblazer-option-0.1.1.gem (100%)
Successfully installed trailblazer-option-0.1.1
Fetching: representable-3.1.1.gem (100%)
ERROR:  Error installing embulk-input-google_analytics:
	representable requires Ruby version >= 2.4.0.
```

## After this PR

```
embulk gem install pkg/embulk-input-google_analytics-0.1.24.gem
2021-04-15 18:16:18.885 +0900: Embulk v0.9.23

Gem plugin path is: /Users/user/.embulk/lib/gems

Fetching: perfect_retry-0.5.0.gem (100%)
Successfully installed perfect_retry-0.5.0
Fetching: declarative-option-0.1.0.gem (100%)
Successfully installed declarative-option-0.1.0
Fetching: declarative-0.0.20.gem (100%)
Successfully installed declarative-0.0.20
Fetching: uber-0.1.0.gem (100%)
Successfully installed uber-0.1.0
Fetching: representable-3.0.4.gem (100%)
Successfully installed representable-3.0.4
Fetching: concurrent-ruby-1.1.8.gem (100%)
Successfully installed concurrent-ruby-1.1.8
Fetching: i18n-1.8.10.gem (100%)
Successfully installed i18n-1.8.10
Fetching: thread_safe-0.3.6-java.gem (100%)
Successfully installed thread_safe-0.3.6-java
Fetching: tzinfo-1.2.9.gem (100%)
Successfully installed tzinfo-1.2.9
Fetching: activesupport-5.2.3.gem (100%)
Successfully installed activesupport-5.2.3
Fetching: multipart-post-2.1.1.gem (100%)
Successfully installed multipart-post-2.1.1
Fetching: faraday-0.17.4.gem (100%)
Successfully installed faraday-0.17.4
Fetching: multi_json-1.15.0.gem (100%)
Successfully installed multi_json-1.15.0
Fetching: jwt-2.2.2.gem (100%)
Successfully installed jwt-2.2.2
Fetching: public_suffix-4.0.6.gem (100%)
Successfully installed public_suffix-4.0.6
Fetching: addressable-2.7.0.gem (100%)
Successfully installed addressable-2.7.0
Fetching: signet-0.10.0.gem (100%)
Successfully installed signet-0.10.0
Fetching: retriable-3.1.2.gem (100%)
Successfully installed retriable-3.1.2
Fetching: mini_mime-1.1.0.gem (100%)
Successfully installed mini_mime-1.1.0
Fetching: memoist-0.16.2.gem (100%)
Successfully installed memoist-0.16.2
Fetching: os-1.1.1.gem (100%)
Successfully installed os-1.1.1
Fetching: googleauth-0.9.0.gem (100%)
Successfully installed googleauth-0.9.0
Fetching: httpclient-2.8.3.gem (100%)
Successfully installed httpclient-2.8.3
Fetching: google-api-client-0.32.1.gem (100%)
Successfully installed google-api-client-0.32.1
Successfully installed embulk-input-google_analytics-0.1.24
25 gems installed
```


